### PR TITLE
Build manylinux wheels for Python 2.7-3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
-sudo: false
-language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+
+matrix:
+  include:
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+            PRE_CMD=linux32
+
+
 install:
-  - pip install six blist unittest2 pytz
-  - python setup.py install
-script: python tests/tests.py
+  - docker pull $DOCKER_IMAGE
+
+script:
+  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.travis/linux-manywheel.sh

--- a/.travis/linux-manywheel.sh
+++ b/.travis/linux-manywheel.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eux
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    if [ $(echo "${PYBIN}" | grep -o '[[:digit:]][[:digit:]]' | head -n 1) -ge 27 ]; then
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    fi
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+
+# Install packages and test
+for PYBIN in /opt/python/*/bin/; do
+    if [ $(echo "${PYBIN}" | grep -o '[[:digit:]][[:digit:]]' | head -n 1) -ge 27 ]; then
+        "${PYBIN}/pip" install ujson --no-index -f /io/wheelhouse
+    fi
+done
+
+# run tests
+for PYBIN in /opt/python/*/bin; do
+    if [ $(echo "${PYBIN}" | grep -o '[[:digit:]][[:digit:]]' | head -n 1) -ge 27 ]; then
+        "${PYBIN}/pip" install six blist unittest2 pytz
+        "${PYBIN}/python" /io/tests/tests.py
+    fi
+done


### PR DESCRIPTION
Using the docker images, we can build manylinux wheels. 2.6 is not
supported as unittests causes issues (doesnt support Unicode)