### PR TITLE
Fix handling of surrogate pseudocharacters under Python 3.

### DIFF
--- a/python/py_defines.h
+++ b/python/py_defines.h
@@ -50,4 +50,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 
 #define PyString_FromString     PyUnicode_FromString
 
+#define PyUnicode_AsUTF8String(o) \
+    (PyUnicode_AsEncodedString((o), "utf-8", "surrogatepass"))
+
 #endif

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -167,6 +167,13 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(enc, json_unicode(input))
         self.assertEqual(dec, json.loads(enc))
 
+    def test_encodeUnicodeBogusSurrogate(self):
+        input = u'"\udcff"'
+        enc = ujson.encode(input)
+        dec = ujson.decode(enc)
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
+
     def test_encodeUnicode4BytesUTF8(self):
         input = "\xf0\x91\x80\xb0TRAILINGNORMAL"
         enc = ujson.encode(input)
@@ -807,11 +814,6 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_WriteArrayOfSymbolsFromTuple(self):
         self.assertEqual("[true,false,null]", ujson.dumps((True, False, None)))
-
-    @unittest.skipIf(not six.PY3, "Only raises on Python 3")
-    def test_encodingInvalidUnicodeCharacter(self):
-        s = "\udc7f"
-        self.assertRaises(UnicodeEncodeError, ujson.dumps, s)
 
     def test_sortKeys(self):
         data = {"a": 1, "c": 1, "b": 1, "e": 1, "f": 1, "d": 1}


### PR DESCRIPTION
This is a situation where we have a Python unicode string which doesn't
consist entirely of genuine Unicode characters -- some of the codepoints
in the string are surrogate codepoints, which occur in a UTF-16 encoding
of a string and were also repurposed in PEP 383 for losslessly encoding
arbitrary mostly-UTF-8 bytestrings (like Unix filenames) in Python
strings.  Currently, on Python 3, we cause a UnicodeEncodeError if we
try to encode such a string as JSON.

It's not 100% obvious what the right thing to do here is -- this
situation seems like it must reflect a bug somewhere else in the
program or its environment.  But

 * one way we can get such a string is by loading a JSON document
   (perhaps an invalid JSON document? anyway, we load it without error):

   >>> ujson.dumps(ujson.loads('"\\udcff"'))
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
   UnicodeEncodeError: 'utf-8' codec can't encode character '\udcff' in position 0: surrogates not allowed

 * we already pass these strings through without complaint on Python 2;

 * as the included test shows, passing these through matches the
   behavior of the stdlib's `json` module.

So it seems best to pass them through.

Fixes #156.